### PR TITLE
"Operation" Resource Routes

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -20,7 +20,10 @@ def login():
         return jsonify({"error": f"Field {e} is required."}), 409
 
     with DBService() as db:
-        users = db.fetch_records("user", conditions={"username": username})
+        users = db.fetch_records(
+            "user",
+            conditions={"username": username},
+        )
 
         try:
             user = users[0]

--- a/routes/operation.py
+++ b/routes/operation.py
@@ -40,6 +40,7 @@ def manage_single_operation(operation_id):
     with DBService() as db:
         ops = db.fetch_records(
             "operation",
+            fields=["id", "type", "cost"],
             conditions={"id": operation_id},
         )
 

--- a/routes/operation.py
+++ b/routes/operation.py
@@ -15,3 +15,18 @@ def manage_operations():
         ops = db.fetch_records("operation")
 
     return jsonify({"results": ops}), 200
+
+
+@operation_bp.route("/<int:operation_id>", methods=["GET"])
+@jwt_required
+def manage_single_operation(operation_id):
+    with DBService() as db:
+        ops = db.fetch_records(
+            "operation",
+            conditions={"id": operation_id},
+        )
+
+    try:
+        return jsonify(ops[0]), 200
+    except IndexError:
+        return jsonify({"error": f"Operation with ID {operation_id} not found"}), 404

--- a/routes/operation.py
+++ b/routes/operation.py
@@ -35,7 +35,7 @@ def manage_operations():
         return jsonify({"id": op_id, "type": op_type, "cost": cost}), 201
 
 
-@operation_bp.route("/<int:operation_id>", methods=["GET", "PUT"])
+@operation_bp.route("/<int:operation_id>", methods=["GET", "PUT", "DELETE"])
 @jwt_required
 def manage_single_operation(operation_id):
     if request.method == "GET":
@@ -76,3 +76,52 @@ def manage_single_operation(operation_id):
             )
 
         return jsonify(updated_ops[0]), 200
+    elif request.method == "DELETE":
+        with DBService() as db:
+            to_delete = db.fetch_records(
+                "operation",
+                conditions={"id": operation_id, "deleted": 0},
+            )
+
+            if not len(to_delete):
+                return (
+                    jsonify({"error": f"Operation with ID {operation_id} not found"}),
+                    404,
+                )
+
+            try:
+                db.update_record(
+                    "operation",
+                    {"deleted": 1},
+                    operation_id,
+                )
+            except pymysql.MySQLError as e:
+                return jsonify({"error": e.args[1]}), 400
+
+            # check that it was properly deleted
+            updated_ops = db.fetch_records(
+                "operation",
+                conditions={"id": operation_id},
+            )
+
+            try:
+                if updated_ops[0]["deleted"] == 1:
+                    return (
+                        jsonify(
+                            {
+                                "message": f"Operation with ID {operation_id} was deleted."
+                            }
+                        ),
+                        200,
+                    )
+                else:
+                    return (
+                        jsonify(
+                            {
+                                "error": f"Could not delete operation with ID {operation_id}."
+                            }
+                        ),
+                        500,
+                    )
+            except KeyError:
+                return jsonify({"error": "Unexpected error occurred."}), 500

--- a/routes/operation.py
+++ b/routes/operation.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, jsonify
 
 from services.db_service import DBService
+from services.jwt_service import jwt_required
 
 
 operation_bp = Blueprint("operation", __name__)
@@ -8,6 +9,7 @@ operation_bp = Blueprint("operation", __name__)
 
 @operation_bp.route("", methods=["GET"])
 @operation_bp.route("/", methods=["GET"])
+@jwt_required
 def manage_operations():
     with DBService() as db:
         ops = db.fetch_records("operation")

--- a/routes/operation.py
+++ b/routes/operation.py
@@ -1,0 +1,15 @@
+from flask import Blueprint, jsonify
+
+from services.db_service import DBService
+
+
+operation_bp = Blueprint("operation", __name__)
+
+
+@operation_bp.route("", methods=["GET"])
+@operation_bp.route("/", methods=["GET"])
+def manage_operations():
+    with DBService() as db:
+        ops = db.fetch_records("operation")
+
+    return jsonify({"results": ops}), 200

--- a/routes/operation.py
+++ b/routes/operation.py
@@ -13,7 +13,11 @@ operation_bp = Blueprint("operation", __name__)
 def manage_operations():
     if request.method == "GET":
         with DBService() as db:
-            ops = db.fetch_records("operation")
+            ops = db.fetch_records(
+                "operation",
+                fields=["id", "type", "cost"],
+                conditions={"deleted": 0},
+            )
 
         return jsonify({"results": ops}), 200
     elif request.method == "POST":

--- a/routes/operation.py
+++ b/routes/operation.py
@@ -22,7 +22,7 @@ def manage_operations():
             op_type = data["type"]
             cost = data["cost"]
         except KeyError as e:
-            return jsonify({"error": f"Field '{e}' is required"}), 400
+            return jsonify({"error": f"Field {e} is required"}), 400
 
         with DBService() as db:
             op_id = db.insert_record("operation", {"type": op_type, "cost": cost})

--- a/routes/operation.py
+++ b/routes/operation.py
@@ -1,3 +1,4 @@
+import pymysql
 from flask import Blueprint, jsonify, request
 
 from services.db_service import DBService
@@ -55,12 +56,18 @@ def manage_single_operation(operation_id):
     elif request.method == "PUT":
         data = request.get_json()
 
+        if not len(data):  # no fields provided
+            return jsonify({"error": "You must specify a field to update."}), 400
+
         with DBService() as db:
-            db.update_record(
-                "operation",
-                data,
-                operation_id,
-            )
+            try:
+                db.update_record(
+                    "operation",
+                    data,
+                    operation_id,
+                )
+            except pymysql.MySQLError as e:
+                return jsonify({"error": e.args[1]}), 400
 
             updated_ops = db.fetch_records(
                 "operation",

--- a/routes/router.py
+++ b/routes/router.py
@@ -1,4 +1,5 @@
 from routes.auth import auth_bp
+from routes.operation import operation_bp
 
 
 class Router:
@@ -12,3 +13,6 @@ class Router:
 
         # auth-related routes
         self.flask_app.register_blueprint(auth_bp, url_prefix="/api/v1/auth")
+
+        # resource routes
+        self.flask_app.register_blueprint(operation_bp, url_prefix="/api/v1/operations")

--- a/services/db_service.py
+++ b/services/db_service.py
@@ -6,13 +6,13 @@ from config import DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_DATABASE
 class DBService:
 
     def __init__(self):
-        
+
         self.host = DB_HOST
         self.port = DB_PORT
         self.user = DB_USER
         self.password = DB_PASSWORD
         self.db = DB_DATABASE
-        
+
         self.connection = None
 
     def __enter__(self):
@@ -64,6 +64,19 @@ class DBService:
                 print(f"Error executing query: {e}")
                 return
 
+    def insert_record(self, table, data):
+        """Insert a record into the given table with the data provided."""
+
+        columns = ", ".join(data.keys())
+        placeholders = ", ".join(["%s"] * len(data))
+        sql = f"INSERT INTO {table} ({columns}) VALUES ({placeholders})"
+
+        with self.connection.cursor() as cursor:
+            cursor.execute(sql, tuple(data.values()))
+            self.connection.commit()
+
+            return cursor.lastrowid
+
     def fetch_records(self, table, conditions=None):
         """Fetch records from a specified table with optional conditions."""
 
@@ -71,7 +84,9 @@ class DBService:
         params = tuple()
 
         if conditions:
-            condition_str = " WHERE " + " AND ".join(f"{k}=%s" for k in conditions.keys())
+            condition_str = " WHERE " + " AND ".join(
+                f"{k}=%s" for k in conditions.keys()
+            )
             params = tuple(conditions.values())
 
         query = f"SELECT * FROM {table}{condition_str}"

--- a/services/db_service.py
+++ b/services/db_service.py
@@ -77,6 +77,20 @@ class DBService:
 
             return cursor.lastrowid
 
+    def update_record(self, table, data, record_id):
+        """Update the requested record with the data provided."""
+
+        set_str = ", ".join(f"{key} = %s" for key in data.keys())
+        sql = f"UPDATE {table} SET {set_str} WHERE id = %s"
+
+        params = tuple(data.values()) + (record_id,)
+
+        with self.connection.cursor() as cursor:
+            cursor.execute(sql, params)
+            self.connection.commit()
+
+            return cursor.lastrowid
+
     def fetch_records(self, table, fields=["*"], conditions=None):
         """Fetch records from a specified table with optional conditions."""
 
@@ -89,7 +103,7 @@ class DBService:
             )
             params = tuple(conditions.values())
 
-        fields_str = ", ".join(f"`{f}`" for f in fields)
+        fields_str = ", ".join(f"`{f}`" if f != "*" else f for f in fields)
 
         query = f"SELECT {fields_str} FROM {table}{condition_str}"
 

--- a/services/db_service.py
+++ b/services/db_service.py
@@ -67,7 +67,7 @@ class DBService:
     def insert_record(self, table, data):
         """Insert a record into the given table with the data provided."""
 
-        columns = ", ".join(data.keys())
+        columns = ", ".join(f"`{k}`" for k in data.keys())
         placeholders = ", ".join(["%s"] * len(data))
         sql = f"INSERT INTO {table} ({columns}) VALUES ({placeholders})"
 
@@ -77,7 +77,7 @@ class DBService:
 
             return cursor.lastrowid
 
-    def fetch_records(self, table, conditions=None):
+    def fetch_records(self, table, fields=["*"], conditions=None):
         """Fetch records from a specified table with optional conditions."""
 
         condition_str = ""
@@ -89,6 +89,8 @@ class DBService:
             )
             params = tuple(conditions.values())
 
-        query = f"SELECT * FROM {table}{condition_str}"
+        fields_str = ", ".join(f"`{f}`" for f in fields)
+
+        query = f"SELECT {fields_str} FROM {table}{condition_str}"
 
         return self.execute_query(query, params)

--- a/services/jwt_service.py
+++ b/services/jwt_service.py
@@ -50,3 +50,5 @@ def jwt_required(f):
             return jsonify(decoded), 401
 
         return f(*args, **kwargs)
+
+    return wrapper

--- a/services/jwt_service.py
+++ b/services/jwt_service.py
@@ -41,7 +41,7 @@ def jwt_required(f):
     def wrapper(*args, **kwargs):
         auth_header = request.headers.get("Authorization")
         if not auth_header or not auth_header.startswith("Bearer "):
-            return jsonify({"error": "Mising or invalid authorization header"}), 401
+            return jsonify({"error": "Missing or invalid authorization header"}), 401
 
         token = auth_header.split(" ")[1]
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE `user` (
 -- operation stores a calculator operation (e.g. addition, subtraction)
 CREATE TABLE operation (
     `id` MEDIUMINT NOT NULL AUTO_INCREMENT,
-    `type` VARCHAR(32) NOT NULL,
+    `type` VARCHAR(32) UNIQUE NOT NULL,
     `cost` DECIMAL(15, 2) NOT NULL,
     `deleted` BOOLEAN DEFAULT FALSE,
     PRIMARY KEY (id)

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -18,8 +18,9 @@ CREATE TABLE `user` (
 -- operation stores a calculator operation (e.g. addition, subtraction)
 CREATE TABLE operation (
     `id` MEDIUMINT NOT NULL AUTO_INCREMENT,
-    `type` ENUM('addition', 'subtraction', 'multiplication', 'division', 'square_root', 'random_string') NOT NULL,
+    `type` VARCHAR(32) NOT NULL,
     `cost` DECIMAL(15, 2) NOT NULL,
+    `deleted` BOOLEAN DEFAULT FALSE,
     PRIMARY KEY (id)
 );
 
@@ -32,6 +33,7 @@ CREATE TABLE record (
     `user_balance` DECIMAL(15, 2) NOT NULL,
     `operation_response` JSON NOT NULL,
     `date` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `deleted` BOOLEAN DEFAULT FALSE,
     PRIMARY KEY (id),
     CONSTRAINT `user_id` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
     CONSTRAINT `operation_id` FOREIGN KEY (`operation_id`) REFERENCES `operation`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -67,3 +67,37 @@ def test_get_operations(mock_db_service, client, auth_header):
     assert response.status_code == 200
     json_data = response.get_json()
     assert json_data == {"results": mock_operations}
+
+
+@patch("routes.operation.DBService")
+def test_get_op_by_id(mock_db_service, client, auth_header):
+
+    mock_operation = {"id": 5, "type": "square_root", "cost": 0.75}
+
+    mock_db_service.return_value.__enter__.return_value.fetch_records.return_value = [
+        mock_operation
+    ]
+
+    response = client.get("/api/v1/operations/5", headers=auth_header)
+
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert json_data == mock_operation
+
+
+@patch("routes.operation.DBService")
+def test_get_op_by_id_not_found(mock_db_service, client, auth_header):
+
+    mock_db_service.return_value.__enter__.return_value.fetch_records.return_value = []
+
+    response = client.get("/api/v1/operations/999", headers=auth_header)
+
+    assert response.status_code == 404
+    json_data = response.get_json()
+    assert json_data == {"error": "Operation with ID 999 not found"}
+
+
+def test_get_op_by_id_is_protected(client):
+
+    response = client.get("/api/v1/operations/1")
+    assert response.status_code == 401

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -28,7 +28,7 @@ def test_get_operations(mock_db_service, client):
         mock_operations
     )
 
-    response = client.post("/api/v1/operations")
+    response = client.get("/api/v1/operations")
 
     assert response.status_code == 200
     json_data = response.get_json()

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -190,3 +190,29 @@ def test_update_operation(mock_db_service, client, auth_header):
     assert response.status_code == 200
     json_data = response.get_json()
     assert json_data == {"id": 3, "type": "multiplication", "cost": 0.99}
+
+
+def test_update_op_is_protected(client):
+
+    operation_data = {"cost": 0.99}
+
+    response = client.put(
+        "/api/v1/operations/3",
+        json=operation_data,
+    )
+
+    assert response.status_code == 401
+
+
+def test_update_op_no_fields_provided(client, auth_header):
+
+    operation_data = {}
+
+    response = client.put(
+        "/api/v1/operations/3",
+        json=operation_data,
+        headers=auth_header,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "You must specify a field to update."}

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from app import app
+from services.jwt_service import JWTService
 
 
 @pytest.fixture
@@ -12,8 +13,14 @@ def client():
         yield client
 
 
+@pytest.fixture
+def auth_header():
+    token = JWTService().generate_token(user_id=1)
+    return {"Authorization": f"Bearer {token}"}
+
+
 @patch("routes.operation.DBService")
-def test_get_operations(mock_db_service, client):
+def test_get_operations(mock_db_service, client, auth_header):
 
     mock_operations = [
         {"id": 1, "type": "addition", "cost": 0.1},
@@ -28,7 +35,7 @@ def test_get_operations(mock_db_service, client):
         mock_operations
     )
 
-    response = client.get("/api/v1/operations")
+    response = client.get("/api/v1/operations", headers=auth_header)
 
     assert response.status_code == 200
     json_data = response.get_json()

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -176,13 +176,13 @@ def test_update_operation(mock_db_service, client, auth_header):
 
     mock_db_service.return_value.__enter__.return_value.update_record.return_value = 3
     mock_db_service.return_value.__enter__.return_value.fetch_records.return_value = [
-        {"id": 3, "type": "multiplication", "cost": 0.25},
+        {"id": 3, "type": "multiplication", "cost": 0.99},
     ]
 
     operation_data = {"cost": 0.99}
 
     response = client.put(
-        "/api/v1/operation/3",
+        "/api/v1/operations/3",
         json=operation_data,
         headers=auth_header,
     )

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+
+import pytest
+
+from app import app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+@patch("routes.operation.DBService")
+def test_get_operations(mock_db_service, client):
+
+    mock_operations = [
+        {"id": 1, "type": "addition", "cost": 0.1},
+        {"id": 2, "type": "subtraction", "cost": 0.1},
+        {"id": 3, "type": "multiplication", "cost": 0.25},
+        {"id": 4, "type": "division", "cost": 0.25},
+        {"id": 5, "type": "square_root", "cost": 0.75},
+        {"id": 6, "type": "random_string", "cost": 1.0},
+    ]
+
+    mock_db_service.return_value.__enter__.return_value.fetch_records.return_value = (
+        mock_operations
+    )
+
+    response = client.post("/api/v1/operations")
+
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert json_data == {"results": mock_operations}

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -174,7 +174,7 @@ def test_create_op_is_protected(client):
 @patch("routes.operation.DBService")
 def test_update_operation(mock_db_service, client, auth_header):
 
-    mock_db_service.return_value.__enter__.return_value.update_record.return_value = 3
+    mock_db_service.return_value.__enter__.return_value.update_record.return_value = 1
     mock_db_service.return_value.__enter__.return_value.fetch_records.return_value = [
         {"id": 3, "type": "multiplication", "cost": 0.99},
     ]
@@ -216,3 +216,17 @@ def test_update_op_no_fields_provided(client, auth_header):
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "You must specify a field to update."}
+
+
+@patch("routes.operation.DBService")
+def test_delete_op(mock_db_service, client, auth_header):
+
+    mock_db_service.return_value.__enter__.return_value.update_record.return_value = 1
+
+    response = client.delete(
+        "/api/v1/operations/3",
+        headers=auth_header,
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "Operation with ID 3 was deleted."}

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -19,6 +19,33 @@ def auth_header():
     return {"Authorization": f"Bearer {token}"}
 
 
+def test_get_operations_no_auth(client):
+
+    response = client.get("/api/v1/operations")
+
+    assert response.status_code == 401
+    json_data = response.get_json()
+    assert json_data == {"error": "Missing or invalid authorization header"}
+
+
+def test_get_operations_invalid_auth(client):
+
+    invalid_auth = {"Authorization": "Bearer not-a-jwt"}
+    response = client.get("/api/v1/operations", headers=invalid_auth)
+
+    assert response.status_code == 401
+    json_data = response.get_json()
+    assert json_data == {"error": "Invalid token"}
+
+    expired_token = JWTService(expiration_hours=-1).generate_token(user_id=1)
+    expired_auth = {"Authorization": f"Bearer {expired_token}"}
+    response = client.get("/api/v1/operations", headers=expired_auth)
+
+    assert response.status_code == 401
+    json_data = response.get_json()
+    assert json_data == {"error": "Token has expired"}
+
+
 @patch("routes.operation.DBService")
 def test_get_operations(mock_db_service, client, auth_header):
 

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -108,50 +108,50 @@ def test_create_operation(mock_db_service, client, auth_header):
 
     mock_db_service.return_value.__enter__.return_value.insert_record.return_value = 1
 
-    item_data = {"type": "modulo", "cost": 0.35}
+    operation_data = {"type": "modulo", "cost": 0.35}
 
     response = client.post(
         "/api/v1/operations",
-        json=item_data,
+        json=operation_data,
         headers=auth_header,
     )
 
     assert response.status_code == 201
     json_data = response.get_json()
-    assert json_data == item_data | {"id": 1}
+    assert json_data == operation_data | {"id": 1}
 
     mock_db_service.return_value.__enter__.return_value.insert_record.assert_called_once_with(
-        "operation", item_data
+        "operation", operation_data
     )
 
 
 @patch("routes.operation.DBService")
 def test_create_op_missing_fields(mock_db_service, client, auth_header):
 
-    item_data = {"cost": 0.35}
+    operation_data = {"cost": 0.35}
     response = client.post(
         "/api/v1/operations",
-        json=item_data,
+        json=operation_data,
         headers=auth_header,
     )
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "Field 'type' is required"}
 
-    item_data = {"type": "modulo"}
+    operation_data = {"type": "modulo"}
     response = client.post(
         "/api/v1/operations",
-        json=item_data,
+        json=operation_data,
         headers=auth_header,
     )
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "Field 'cost' is required"}
 
-    item_data = {}
+    operation_data = {}
     response = client.post(
         "/api/v1/operations",
-        json=item_data,
+        json=operation_data,
         headers=auth_header,
     )
 
@@ -161,11 +161,32 @@ def test_create_op_missing_fields(mock_db_service, client, auth_header):
 
 def test_create_op_is_protected(client):
 
-    item_data = {"type": "modulo", "cost": 0.35}
+    operation_data = {"type": "modulo", "cost": 0.35}
 
     response = client.post(
         "/api/v1/operations",
-        json=item_data,
+        json=operation_data,
     )
 
     assert response.status_code == 401
+
+
+@patch("routes.operation.DBService")
+def test_update_operation(mock_db_service, client, auth_header):
+
+    mock_db_service.return_value.__enter__.return_value.update_record.return_value = 3
+    mock_db_service.return_value.__enter__.return_value.fetch_records.return_value = [
+        {"id": 3, "type": "multiplication", "cost": 0.25},
+    ]
+
+    operation_data = {"cost": 0.99}
+
+    response = client.put(
+        "/api/v1/operation/3",
+        json=operation_data,
+        headers=auth_header,
+    )
+
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert json_data == {"id": 3, "type": "multiplication", "cost": 0.99}

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -101,3 +101,25 @@ def test_get_op_by_id_is_protected(client):
 
     response = client.get("/api/v1/operations/1")
     assert response.status_code == 401
+
+
+@patch("routes.operation.DBService")
+def test_create_operation(mock_db_service, client, auth_header):
+
+    mock_db_service.return_value.__enter__.return_value.insert_record.return_value = 1
+
+    item_data = {"type": "modulo", "cost": 0.35}
+
+    response = client.post(
+        "/api/v1/operations",
+        json=item_data,
+        headers=auth_header,
+    )
+
+    assert response.status_code == 201
+    json_data = response.get_json()
+    assert json_data == item_data | {"id": 1}
+
+    mock_db_service.return_value.__enter__.return_value.insert_record.assert_called_once_with(
+        "operation", item_data
+    )

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -222,6 +222,9 @@ def test_update_op_no_fields_provided(client, auth_header):
 def test_delete_op(mock_db_service, client, auth_header):
 
     mock_db_service.return_value.__enter__.return_value.update_record.return_value = 1
+    mock_db_service.return_value.__enter__.return_value.fetch_records.return_value = [
+        {"id": 3, "type": "multiplication", "cost": 0.1, "deleted": 1}
+    ]
 
     response = client.delete(
         "/api/v1/operations/3",

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -123,3 +123,49 @@ def test_create_operation(mock_db_service, client, auth_header):
     mock_db_service.return_value.__enter__.return_value.insert_record.assert_called_once_with(
         "operation", item_data
     )
+
+
+@patch("routes.operation.DBService")
+def test_create_op_missing_fields(mock_db_service, client, auth_header):
+
+    item_data = {"cost": 0.35}
+    response = client.post(
+        "/api/v1/operations",
+        json=item_data,
+        headers=auth_header,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Field 'type' is required"}
+
+    item_data = {"type": "modulo"}
+    response = client.post(
+        "/api/v1/operations",
+        json=item_data,
+        headers=auth_header,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Field 'cost' is required"}
+
+    item_data = {}
+    response = client.post(
+        "/api/v1/operations",
+        json=item_data,
+        headers=auth_header,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Field 'type' is required"}
+
+
+def test_create_op_is_protected(client):
+
+    item_data = {"type": "modulo", "cost": 0.35}
+
+    response = client.post(
+        "/api/v1/operations",
+        json=item_data,
+    )
+
+    assert response.status_code == 401


### PR DESCRIPTION
This PR introduces CRUD routes for the operation resource, with accompanying unit tests. The following routes are implemented:

 - `GET /api/v1/operations` -- get all operations
 - `GET /api/v1/operations/<operation_id>` -- get operation by ID
 - `POST /api/v1/operations` -- create a new operation
 - `PUT /api/v1/operations/<operation_id>` -- update an operation (type or cost)
 - `DELETE /api/v1/operations/<operation_id>` -- perform a *soft delete* on the operation

Since I don't necessarily want all of these available to a user (a user should not be able to log in and add operations to the calculator), I'll probably soon implement an admin authorization system to give the PUT/POST/DELETE routes an additional layer of protection.