### PR TITLE
Admin Protection for Certain Routes

### DIFF
--- a/routes/operation.py
+++ b/routes/operation.py
@@ -2,126 +2,133 @@ import pymysql
 from flask import Blueprint, jsonify, request
 
 from services.db_service import DBService
-from services.jwt_service import jwt_required
+from services.jwt_service import jwt_required, admin_protected
 
 
 operation_bp = Blueprint("operation", __name__)
 
 
-@operation_bp.route("", methods=["GET", "POST"])
-@operation_bp.route("/", methods=["GET", "POST"])
+@operation_bp.route("", methods=["GET"])
+@operation_bp.route("/", methods=["GET"])
 @jwt_required
-def manage_operations():
-    if request.method == "GET":
-        with DBService() as db:
-            ops = db.fetch_records(
-                "operation",
-                fields=["id", "type", "cost"],
-                conditions={"deleted": 0},
-            )
+def get_operations():
+    with DBService() as db:
+        ops = db.fetch_records(
+            "operation",
+            fields=["id", "type", "cost"],
+            conditions={"deleted": 0},
+        )
 
-        return jsonify({"results": ops}), 200
-    elif request.method == "POST":
-        data = request.get_json()
-        try:
-            op_type = data["type"]
-            cost = data["cost"]
-        except KeyError as e:
-            return jsonify({"error": f"Field {e} is required"}), 400
-
-        with DBService() as db:
-            op_id = db.insert_record("operation", {"type": op_type, "cost": cost})
-
-        return jsonify({"id": op_id, "type": op_type, "cost": cost}), 201
+    return jsonify({"results": ops}), 200
 
 
-@operation_bp.route("/<int:operation_id>", methods=["GET", "PUT", "DELETE"])
+@operation_bp.route("", methods=["POST"])
+@operation_bp.route("/", methods=["POST"])
+@admin_protected
+def create_operation():
+    data = request.get_json()
+    try:
+        op_type = data["type"]
+        cost = data["cost"]
+    except KeyError as e:
+        return jsonify({"error": f"Field {e} is required"}), 400
+
+    with DBService() as db:
+        op_id = db.insert_record("operation", {"type": op_type, "cost": cost})
+
+    return jsonify({"id": op_id, "type": op_type, "cost": cost}), 201
+
+
+@operation_bp.route("/<int:operation_id>", methods=["GET"])
 @jwt_required
-def manage_single_operation(operation_id):
-    if request.method == "GET":
-        with DBService() as db:
-            ops = db.fetch_records(
-                "operation",
-                fields=["id", "type", "cost"],
-                conditions={"id": operation_id},
-            )
+def get_single_operation(operation_id):
+    with DBService() as db:
+        ops = db.fetch_records(
+            "operation",
+            fields=["id", "type", "cost"],
+            conditions={"id": operation_id},
+        )
 
+    try:
+        return jsonify(ops[0]), 200
+    except IndexError:
+        return (
+            jsonify({"error": f"Operation with ID {operation_id} not found"}),
+            404,
+        )
+
+
+@operation_bp.route("/<int:operation_id>", methods=["PUT"])
+@admin_protected
+def update_single_operation(operation_id):
+    data = request.get_json()
+
+    if not len(data):  # no fields provided
+        return jsonify({"error": "You must specify a field to update."}), 400
+
+    with DBService() as db:
         try:
-            return jsonify(ops[0]), 200
-        except IndexError:
+            db.update_record(
+                "operation",
+                data,
+                operation_id,
+            )
+        except pymysql.MySQLError as e:
+            return jsonify({"error": e.args[1]}), 400
+
+        updated_ops = db.fetch_records(
+            "operation",
+            fields=["id", "type", "cost"],
+            conditions={"deleted": 0, "id": operation_id},
+        )
+
+    return jsonify(updated_ops[0]), 200
+
+
+@operation_bp.route("/<int:operation_id>", methods=["DELETE"])
+@admin_protected
+def delete_operation(operation_id):
+    with DBService() as db:
+        to_delete = db.fetch_records(
+            "operation",
+            conditions={"id": operation_id, "deleted": 0},
+        )
+
+        if not len(to_delete):
             return (
                 jsonify({"error": f"Operation with ID {operation_id} not found"}),
                 404,
             )
-    elif request.method == "PUT":
-        data = request.get_json()
 
-        if not len(data):  # no fields provided
-            return jsonify({"error": "You must specify a field to update."}), 400
-
-        with DBService() as db:
-            try:
-                db.update_record(
-                    "operation",
-                    data,
-                    operation_id,
-                )
-            except pymysql.MySQLError as e:
-                return jsonify({"error": e.args[1]}), 400
-
-            updated_ops = db.fetch_records(
+        try:
+            db.update_record(
                 "operation",
-                fields=["id", "type", "cost"],
-                conditions={"deleted": 0, "id": operation_id},
+                {"deleted": 1},
+                operation_id,
             )
+        except pymysql.MySQLError as e:
+            return jsonify({"error": e.args[1]}), 400
 
-        return jsonify(updated_ops[0]), 200
-    elif request.method == "DELETE":
-        with DBService() as db:
-            to_delete = db.fetch_records(
-                "operation",
-                conditions={"id": operation_id, "deleted": 0},
-            )
+        # check that it was properly deleted
+        updated_ops = db.fetch_records(
+            "operation",
+            conditions={"id": operation_id},
+        )
 
-            if not len(to_delete):
+        try:
+            if updated_ops[0]["deleted"] == 1:
                 return (
-                    jsonify({"error": f"Operation with ID {operation_id} not found"}),
-                    404,
+                    jsonify(
+                        {"message": f"Operation with ID {operation_id} was deleted."}
+                    ),
+                    200,
                 )
-
-            try:
-                db.update_record(
-                    "operation",
-                    {"deleted": 1},
-                    operation_id,
+            else:
+                return (
+                    jsonify(
+                        {"error": f"Could not delete operation with ID {operation_id}."}
+                    ),
+                    500,
                 )
-            except pymysql.MySQLError as e:
-                return jsonify({"error": e.args[1]}), 400
-
-            # check that it was properly deleted
-            updated_ops = db.fetch_records(
-                "operation",
-                conditions={"id": operation_id},
-            )
-
-            try:
-                if updated_ops[0]["deleted"] == 1:
-                    return (
-                        jsonify(
-                            {
-                                "message": f"Operation with ID {operation_id} was deleted."
-                            }
-                        ),
-                        200,
-                    )
-                else:
-                    return (
-                        jsonify(
-                            {
-                                "error": f"Could not delete operation with ID {operation_id}."
-                            }
-                        ),
-                        500,
-                    )
-            except KeyError:
-                return jsonify({"error": "Unexpected error occurred."}), 500
+        except KeyError:
+            return jsonify({"error": "Unexpected error occurred."}), 500

--- a/scripts/new_admin_key.py
+++ b/scripts/new_admin_key.py
@@ -1,0 +1,30 @@
+"""Generate a new admin API key and store it in the database."""
+
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from services.db_service import DBService
+from services.jwt_service import JWTService
+
+created_by = input('\nEnter a value for "created_by" >> ')
+description = input('\nEnter a value for "description" >> ')
+print()
+
+token = JWTService().generate_admin_token(created_by, description)
+
+print(f"\nYour new admin key:\n{token}")
+print("\nStoring your key in the database...\n")
+
+with DBService() as db:
+    db.insert_record(
+        "admin_key",
+        {
+            "api_key": token,
+            "created_by": created_by or None,
+            "description": description or None,
+        },
+    )
+
+print("Done!")

--- a/services/jwt_service.py
+++ b/services/jwt_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import jwt
 from flask import request, jsonify
 
+from db_service import DBService
 from config import JWT_SECRET, JWT_ALGORITHM, JWT_EXPIRATION_HOURS
 
 
@@ -58,6 +59,43 @@ def jwt_required(f):
         decoded = JWTService().verify_token(token)
         if "error" in decoded:
             return jsonify(decoded), 401
+
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+def admin_protected(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        auth_header = request.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            return jsonify({"error": "Missing or invalid authorization header"}), 401
+
+        token = auth_header.split(" ")[1]
+
+        decoded = JWTService().verify_token(token)
+        if "error" in decoded:
+            return jsonify(decoded), 401
+
+        if "role" not in token or token["role"] != "admin":
+            return (
+                jsonify(
+                    {
+                        "error": "An admin API key is required to use this endpoint. Please contact an administrator if you need a key."
+                    }
+                ),
+                403,
+            )
+
+        with DBService() as db:
+            results = db.fetch_records(
+                "admin_key",
+                conditions={"api_key": token, "deleted": False},
+            )
+
+            if not results:
+                return jsonify({"error": "Invalid or inactive API key."}), 401
 
         return f(*args, **kwargs)
 

--- a/services/jwt_service.py
+++ b/services/jwt_service.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import jwt
 from flask import request, jsonify
 
-from db_service import DBService
+from services.db_service import DBService
 from config import JWT_SECRET, JWT_ALGORITHM, JWT_EXPIRATION_HOURS
 
 
@@ -78,7 +78,7 @@ def admin_protected(f):
         if "error" in decoded:
             return jsonify(decoded), 401
 
-        if "role" not in token or token["role"] != "admin":
+        if "role" not in decoded or decoded["role"] != "admin":
             return (
                 jsonify(
                     {

--- a/services/jwt_service.py
+++ b/services/jwt_service.py
@@ -27,6 +27,16 @@ class JWTService:
 
         return jwt.encode(payload, self.secret_key, algorithm=self.algorithm)
 
+    def generate_admin_token(self, created_by, description):
+
+        payload = {
+            "role": "admin",
+            "created_by": created_by,
+            "description": description,
+        }
+
+        return jwt.encode(payload, self.secret_key, algorithm=self.algorithm)
+
     def verify_token(self, token):
         try:
             return jwt.decode(token, self.secret_key, algorithms=[self.algorithm])

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -38,3 +38,14 @@ CREATE TABLE record (
     CONSTRAINT `user_id` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
     CONSTRAINT `operation_id` FOREIGN KEY (`operation_id`) REFERENCES `operation`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE
 );
+
+-- admin_key stores administrator API keys
+CREATE TABLE admin_key (
+    `id` MEDIUMINT NOT NULL AUTO_INCREMENT,
+    `api_key` VARCHAR(64) NOT NULL UNIQUE,
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `created_by` VARCHAR(255),
+    `description` VARCHAR(255),
+    `deleted` BOOLEAN DEFAULT FALSE,
+    PRIMARY KEY (id)
+);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -5,6 +5,7 @@ USE calculator_service;
 DROP TABLE IF EXISTS record;
 DROP TABLE IF EXISTS `user`;
 DROP TABLE IF EXISTS operation;
+DROP TABLE IF EXISTS admin_key;
 
 -- user stores users with their login information
 CREATE TABLE `user` (
@@ -42,7 +43,7 @@ CREATE TABLE record (
 -- admin_key stores administrator API keys
 CREATE TABLE admin_key (
     `id` MEDIUMINT NOT NULL AUTO_INCREMENT,
-    `api_key` VARCHAR(64) NOT NULL UNIQUE,
+    `api_key` VARCHAR(255) NOT NULL UNIQUE,
     `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     `created_by` VARCHAR(255),
     `description` VARCHAR(255),


### PR DESCRIPTION
Since I don't want an ordinary user to access certain API endpoints (e.g. calculator operation creation/deletion), I've introduced a new authorization system in the form of "admin" keys. These are separate from normal "user" keys which are generated when a user logs in.

This allows these routes to be accessible to administrators like myself while still protecting them from ordinary users.