### PR TITLE
API Pagination

### DIFF
--- a/tests/test_calculation_routes.py
+++ b/tests/test_calculation_routes.py
@@ -105,15 +105,22 @@ def test_get_previous_calculations(mock_db_service, client, auth_header):
         },
     ]
 
-    mock_db_service.return_value.__enter__.return_value.execute_query.return_value = (
-        mock_calculations
-    )
+    expected_metadata = {
+        "total": 2,
+        "page": 1,
+        "page_size": 10,
+    }
+
+    mock_db_service.return_value.__enter__.return_value.execute_query.side_effect = [
+        [{"total": 2}],
+        mock_calculations,
+    ]
 
     response = client.get("/api/v1/calculations", headers=auth_header)
 
     assert response.status_code == 200
     json_data = response.get_json()
-    assert json_data == {"results": formatted_results}
+    assert json_data == {"results": formatted_results, "metadata": expected_metadata}
 
 
 def test_run_calculation_is_protected(client):

--- a/tests/test_operation_routes.py
+++ b/tests/test_operation_routes.py
@@ -69,15 +69,22 @@ def test_get_operations(mock_db_service, client, auth_header):
         {"id": 6, "type": "random_string", "cost": 1.0},
     ]
 
+    mock_db_service.return_value.__enter__.return_value.count_records.return_value = 6
+
     mock_db_service.return_value.__enter__.return_value.fetch_records.return_value = (
         mock_operations
     )
+    expected_metadata = {
+        "total": 6,
+        "page": 1,
+        "page_size": 10,
+    }
 
     response = client.get("/api/v1/operations", headers=auth_header)
 
     assert response.status_code == 200
     json_data = response.get_json()
-    assert json_data == {"results": mock_operations}
+    assert json_data == {"results": mock_operations, "metadata": expected_metadata}
 
 
 @patch("routes.operation.DBService")


### PR DESCRIPTION
This PR introduces pagination to two API endpoints: `GET /api/v1/operations`, and `GET /api/v1/calculations`.

To filter on these endpoints, specify the filterable field in the query string:

`GET /api/v1/operations?cost=0.1`

Pagination is handled with two query parameters, `page` (page number) and `page_size` (number of items per-page, limit):

`GET /api/v1/operations?cost=0.1&page_size=2&page=3` (pulls operations 5 and 6 where the operation cost is 10 cents)